### PR TITLE
Allow to pass PSCredential::Empty to Invoke-JenkinsCommand

### DIFF
--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -342,7 +342,7 @@ function Invoke-JenkinsCommand()
         $Body
     )
 
-    if ($PSBoundParameters.ContainsKey('Credential')) {
+    if ($PSBoundParameters.ContainsKey('Credential') -and $Credential -ne [System.Management.Automation.PSCredential]::Empty) {
         # Jenkins Credentials were passed so create the Authorization Header
         $Username = $Credential.Username
 


### PR DESCRIPTION
- make usage of `-Credential` parameter more flexible by explicitly
handling `[System.Management.Automation.PSCredential]::Empty`
- this allows calling code to always set the `-Credential` parameter but
use the `[System.Management.Automation.PSCredential]::Empty` value in case no credentials are available (Otherwise
splatting is required)

I'm using your _Jenkins_ module CmdLets as building blocks for our own high-level jenkins module customized to our infrastructure. I have jenkins instances that do require authentication, some that don't and some that do for specific actions (e.g. trigger jobs). To support that scenario our module allows to register credentials for specific jenkins instances. When calling `Invoke-JenkinsCommand` for example, i might have credentials for the specific instance available or not.

The proposed change allows to just provide `[System.Management.Automation.PSCredential]::Empty` in the latter case, instead of having to splat all parameters and conditionally add `-Credential` only if available.

*Random example call:*

```PowerShell
Get-JenkinsJobList -Uri $this.Url -Credential $(GetCredentials $this)
```

`GetCredentials` here returns the previously configured credentials or just `[System.Management.Automation.PSCredential]::Empty` if none have been set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/61)
<!-- Reviewable:end -->
