### PR TITLE
Install test libraries with scope 'CurrentUser' if not installed yet

### DIFF
--- a/tests/Invoke-Tests.ps1
+++ b/tests/Invoke-Tests.ps1
@@ -11,7 +11,8 @@ if (-not (Get-Module -Name Pester -ListAvailable -ErrorAction SilentlyContinue))
 {
     Install-Module `
         -Name 'Pester' `
-        -Confirm:$False
+        -Confirm:$False `
+        -Scope CurrentUser
 }
 Import-Module `
     -Name 'Pester' `

--- a/tests/unit/Jenkins.tests.ps1
+++ b/tests/unit/Jenkins.tests.ps1
@@ -16,7 +16,8 @@ try
     {
         Install-Module `
             -Name 'PSScriptAnalyzer' `
-            -Confirm:$False
+            -Confirm:$False `
+            -Scope CurrentUser
     } # if
     Import-Module `
         -Name 'PSScriptAnalyzer' `


### PR DESCRIPTION
- to avoid requiring an elevated powershell instance for users that want
to run the tests, install required missing modules to 'CurrentUser'
scope only
- has no impact if modules are already installed on the system

Added this to run the tests in the previous PR #61 but decided to add a separate PR because it's completely unrelated. Feel free to reject if the current behavior is on purpose/preferred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/62)
<!-- Reviewable:end -->
