### PR TITLE
Fix Issue - Fixes #64

### DIFF
--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -416,7 +416,7 @@ function Invoke-JenkinsCommand()
                 # Todo: Improve error handling.
                 Throw $_
             } # catch
-        } # 'rest'
+        } # 'restcommand'
         'command' {
             $FullUri = $Uri
             if ($PSBoundParameters.ContainsKey('Command')) {
@@ -440,7 +440,7 @@ function Invoke-JenkinsCommand()
                 # Todo: Improve error handling.
                 Throw $_
             } # catch
-        } # 'rest'
+        } # 'command'
         'pluginmanager' {
             $FullUri = $Uri
             if ($PSBoundParameters.ContainsKey('Command')) {
@@ -464,8 +464,8 @@ function Invoke-JenkinsCommand()
                 # Todo: Improve error handling.
                 Throw $_
             } # catch
-        }
-    } # swtich
+        } # 'pluginmanager'
+    } # switch
     Return $Result
 } # Invoke-JenkinsCommand
 

--- a/en-us/Jenkins_LocalizationData.psd1
+++ b/en-us/Jenkins_LocalizationData.psd1
@@ -6,7 +6,7 @@ ConvertFrom-StringData -StringData @'
     InvokingRestApiCommandMessage = Invoking Rest Api Command '{0}'.
     InvokingCommandMessage = Invoking Command '{0}'.
     InvokeRestApiCommandError = Rest Api Command '{0}' returned '{1}'.
-    UpdateListBadFormatError = The {0} update list file downloaded from '{0}' was in an unexpected format.
+    UpdateListBadFormatError = The {0} update list file downloaded from '{1}' was in an unexpected format.
 
     NewJobMessage = Create the job '{0}'
     NewFolderMessage = Create the folder '{0}'

--- a/en-us/Jenkins_LocalizationData.psd1
+++ b/en-us/Jenkins_LocalizationData.psd1
@@ -7,6 +7,7 @@ ConvertFrom-StringData -StringData @'
     InvokingCommandMessage = Invoking Command '{0}'.
     InvokeRestApiCommandError = Rest Api Command '{0}' returned '{1}'.
     UpdateListBadFormatError = The {0} update list file downloaded from '{1}' was in an unexpected format.
+    SuppressingRedirectMessage = Suppressing redirect-after-command to target URL '{0}'.
 
     NewJobMessage = Create the job '{0}'
     NewFolderMessage = Create the folder '{0}'

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,6 @@ New-JenkinsFolder `
 ```
 
 # Known Issues
- - Remove-JenkinsJob: An IE window pops up after deleting the job for some reason requesting authentication.
  - Initialize-JenkinsUpdateCache: Does not correctly set the signature information in the update-center.json file that is created.
 
 # Recommendations


### PR DESCRIPTION
Implement solution proposed in Issue #64 to fix the "authentication required" after job deletion issue.

The current solution has a few implications that should be considered:

- the MaximumRedirection param was added in `Invoke-JenkinsCommand` for **all** actions of type `command`. Rationale is that in the scripting case, I don't see any reasonable use-case to follow these redirects.
- the changed Error handling does change exception stacks slightly, as a second stack trace from the "delayed" throw is added, that might be a bit distracting to users
- the same approach should maybe be used on all command types that, and in this case maybe needs some more generalization to avoid copy-paste.

Although the PR is mainly meant to discuss a solution, it can potentially also be merged as-is (all tests pass, no new PSScriptAnalyzer warnings AFAIK). It's maybe not the final solution, but does solve the actual issue. I only tested a few use cases that are relevant to me, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/65)
<!-- Reviewable:end -->
