### PR TITLE
Rename-JenkinsJob support - Fixes #66

### DIFF
--- a/Jenkins.psd1
+++ b/Jenkins.psd1
@@ -68,6 +68,7 @@ FunctionsToExport = @(
     'Set-JenkinsJob'
     'Test-JenkinsJob'
     'New-JenkinsJob'
+    'Rename-JenkinsJob'
     'Remove-JenkinsJob'
     'Invoke-JenkinsJob'
     'Get-JenkinsViewList'

--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -1146,6 +1146,88 @@ function Test-JenkinsJob()
 
 <#
 .SYNOPSIS
+    Renames an existing Jenkins Job.
+.DESCRIPTION
+    Renames an existing Jenkins Job in the specified Jenkins Master server.
+    If the job does not exist or a job with the new name exists already an error will occur.
+.PARAMETER Uri
+    Contains the Uri to the Jenkins Master server that contains the existing job.
+.PARAMETER Credential
+    Contains the credentials to use to authenticate with the Jenkins Master server.
+.PARAMETER Crumb
+    Contains a Crumb to pass to the Jenkins Master Server if CSRF is enabled.
+.PARAMETER Name
+    The name of the job to rename.
+.PARAMETER NewName
+    The new name to rename the job to.
+.EXAMPLE
+    Rename-JenkinsJob `
+        -Uri 'https://jenkins.contoso.com' `
+        -Credential (Get-Credential) `
+        -Name 'My App Build' `
+        -NewName 'My Renamed Build' `
+        -Verbose
+    Rename the 'My App Build' job on https://jenkins.contoso.com to 'My Renamed Build' using the credentials provided by
+    the user.
+.OUTPUTS
+    None.
+#>
+function Rename-JenkinsJob()
+{
+    [CmdLetBinding(SupportsShouldProcess=$true,
+        ConfirmImpact="High")]
+    Param
+    (
+        [parameter(
+            Position=1,
+            Mandatory=$true)]
+        [String] $Uri,
+
+        [parameter(
+            Position=2,
+            Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.CredentialAttribute()] $Credential,
+
+        [parameter(
+            Position=3,
+            Mandatory=$false)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Crumb,
+
+        [parameter(
+            Position=4,
+            Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name,
+
+        [parameter(
+            Position=5,
+            Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $NewName,
+        
+        [Switch] $Force
+    )
+    $null = $PSBoundParameters.Add('Type','Command')
+    $Command = "job/$Name/doRename?newName={0}" -f [System.Uri]::EscapeDataString($NewName)
+    $null = $PSBoundParameters.Remove('Name')
+    $null = $PSBoundParameters.Remove('NewName')
+    $null = $PSBoundParameters.Remove('Confirm')
+    $null = $PSBoundParameters.Remove('Force')
+    $null = $PSBoundParameters.Add('Command', $Command)
+    $null = $PSBoundParameters.Add('Method', 'post')
+    if ($Force -or $PSCmdlet.ShouldProcess( `
+        $URI, `
+        $($LocalizedData.RenameJobMessage -f $Name, $NewName))) {
+        $null = Invoke-JenkinsCommand @PSBoundParameters
+    } # if
+} # Rename-JenkinsJob
+
+
+<#
+.SYNOPSIS
     Create a new Jenkins Job.
 .DESCRIPTION
     Creates a new Jenkins Job using the provided XML.
@@ -1161,7 +1243,7 @@ function Test-JenkinsJob()
     The optional job folder the job is in. This requires the Jobs Plugin to be installed on Jenkins.
     If the folder does not exist then an error will occur.
 .PARAMETER Name
-    The name of the job to set the definition on.
+    The name of the job to add.
 .PARAMETER XML
     The config XML of the job to import.
 .EXAMPLE
@@ -1237,7 +1319,7 @@ function New-JenkinsJob()
             $Command += "job/$Folder/"
         } # foreach
     } # if
-    $Command += "createItem?name=$Name"
+    $Command += "createItem?name={0}" -f [System.Uri]::EscapeDataString($Name)
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Folder')
     $null = $PSBoundParameters.Remove('XML')
@@ -1271,7 +1353,7 @@ function New-JenkinsJob()
     The optional job folder the job is in. This requires the Jobs Plugin to be installed on Jenkins.
     If the folder does not exist then an error will occur.
 .PARAMETER Name
-    The name of the job to set the definition on.
+    The name of the job to remove.
 .EXAMPLE
     Remove-JenkinsJob `
         -Uri 'https://jenkins.contoso.com' `

--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -416,7 +416,7 @@ function Invoke-JenkinsCommand()
                 # Todo: Improve error handling.
                 Throw $_
             } # catch
-        } # 'rest'
+        } # 'restcommand'
         'command' {
             $FullUri = $Uri
             if ($PSBoundParameters.ContainsKey('Command')) {
@@ -440,7 +440,7 @@ function Invoke-JenkinsCommand()
                 # Todo: Improve error handling.
                 Throw $_
             } # catch
-        } # 'rest'
+        } # 'command'
         'pluginmanager' {
             $FullUri = $Uri
             if ($PSBoundParameters.ContainsKey('Command')) {
@@ -464,8 +464,8 @@ function Invoke-JenkinsCommand()
                 # Todo: Improve error handling.
                 Throw $_
             } # catch
-        }
-    } # swtich
+        } # 'pluginmanager'
+    } # switch
     Return $Result
 } # Invoke-JenkinsCommand
 

--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -1554,7 +1554,7 @@ function Invoke-JenkinsJob()
         $body = @{ json = (ConvertTo-JSON -InputObject $postObject) }
         $null = $PSBoundParameters.Add('Body',$body)
     }
-    Invoke-JenkinsCommand @PSBoundParameters | Out-Null
+    $null = Invoke-JenkinsCommand @PSBoundParameters
 } # Invoke-JenkinsJob
 
 

--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -1554,7 +1554,7 @@ function Invoke-JenkinsJob()
         $body = @{ json = (ConvertTo-JSON -InputObject $postObject) }
         $null = $PSBoundParameters.Add('Body',$body)
     }
-    $Result = Invoke-JenkinsCommand @PSBoundParameters
+    Invoke-JenkinsCommand @PSBoundParameters | Out-Null
 } # Invoke-JenkinsJob
 
 

--- a/en-us/Jenkins_LocalizationData.psd1
+++ b/en-us/Jenkins_LocalizationData.psd1
@@ -6,7 +6,7 @@ ConvertFrom-StringData -StringData @'
     InvokingRestApiCommandMessage = Invoking Rest Api Command '{0}'.
     InvokingCommandMessage = Invoking Command '{0}'.
     InvokeRestApiCommandError = Rest Api Command '{0}' returned '{1}'.
-    UpdateListBadFormatError = The {0} update list file downloaded from '{0}' was in an unexpected format.
+    UpdateListBadFormatError = The {0} update list file downloaded from '{1}' was in an unexpected format.
 
     NewJobMessage = Create the job '{0}'
     NewFolderMessage = Create the folder '{0}'

--- a/en-us/Jenkins_LocalizationData.psd1
+++ b/en-us/Jenkins_LocalizationData.psd1
@@ -7,6 +7,7 @@ ConvertFrom-StringData -StringData @'
     InvokingCommandMessage = Invoking Command '{0}'.
     InvokeRestApiCommandError = Rest Api Command '{0}' returned '{1}'.
     UpdateListBadFormatError = The {0} update list file downloaded from '{1}' was in an unexpected format.
+    SuppressingRedirectMessage = Suppressing redirect-after-command to target URL '{0}'.
 
     NewJobMessage = Create the job '{0}'
     NewFolderMessage = Create the folder '{0}'

--- a/en-us/Jenkins_LocalizationData.psd1
+++ b/en-us/Jenkins_LocalizationData.psd1
@@ -11,6 +11,7 @@ ConvertFrom-StringData -StringData @'
 
     NewJobMessage = Create the job '{0}'
     NewFolderMessage = Create the folder '{0}'
+    RenameJobMessage = Rename the job '{0}' to '{1}'
     RemoveJobMessage = Delete the job '{0}'
     SetJobDefinitionMessage = Set the job definition for job '{0}'
     UpdateJenkinsPluginMessage = Update Jenkins cached plugin '{0}' to version '{1}'

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,6 @@ New-JenkinsFolder `
 ```
 
 # Known Issues
- - Remove-JenkinsJob: An IE window pops up after deleting the job for some reason requesting authentication.
  - Initialize-JenkinsUpdateCache: Does not correctly set the signature information in the update-center.json file that is created.
 
 # Recommendations

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ Unzip the file containing this Module to your c:\Program Files\WindowsPowerShell
  - Set-JenkinsJob: Set a Jenkins Job definition.
  - Test-JenkinsJob: Determines if a Jenkins Job exists.
  - New-JenkinsJob: Create a new Jenkins Job.
+ - Rename-JenkinsJob: Rename an existing Jenkins Job.
  - Remove-JenkinsJob: Remove an existing Jenkins Job.
  - Invoke-JenkinsJob: Run a parameterized or non-parameterized Jenkins Job.
  - Get-JenkinsViewList: Get a list of views in a Jenkins master server.
@@ -143,6 +144,16 @@ New-JenkinsJob `
     -Credential (Get-Credential) `
     -Name 'My App Build' `
     -XML $MyAppBuildConfig
+```
+
+## Rename an existing job called 'My App Build' to 'Other Build' on a Jenkins Server
+```powershell
+Import-Module -Name Jenkins
+Rename-JenkinsJob `
+    -Uri 'https://jenkins.contoso.com' `
+    -Credential (Get-Credential) `
+    -Name 'My App Build'
+    -NewName 'Other Build'
 ```
 
 ## Remove a job called 'My App Build' from a Jenkins Server


### PR DESCRIPTION
Implementation for Issue #66.

Also contains a fix for `New-JenkinsJob` when the job name contains _unusual chars_ (otherwise the result might not be what was desired, especially when a & is used).

Might need some test cases, although it's just a thin wrapper around `Invoke-JenkinsCommand` for that specific use case.

**Note**: This is based on the code from PR #65, as it also suffers from the same "Authentication required" Issue #64 (caused by a redirect to the new job page after renaming) otherwise. PR needs to be updated after merging PR #65 and should not be integrated before that. 

I'm still filing it for review now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/67)
<!-- Reviewable:end -->
