### PR TITLE
Change Get-JenkinsObject - use passed attributes when folder is specified.

### DIFF
--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -719,6 +719,7 @@ function Get-JenkinsObject()
         $FolderItems = $Folder -split '\\'
         $TreeRequestSplat = @{
             Depth = ($FolderItems.Count + 1)
+            Attribute = $Attribute
         }
     } # if
     $Command = Get-JenkinsTreeRequest @TreeRequestSplat
@@ -1212,7 +1213,7 @@ function Rename-JenkinsJob()
             Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [String] $NewName,
-        
+
         [Switch] $Force
     )
     $null = $PSBoundParameters.Add('Type','Command')

--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,10 @@ For further examples, please see module help for individual cmdlets.
 
 ## Versions
 
+### Unreleased
+
+- Fixed Get-JenkinsObject to use passed attributes when folder is specified.
+
 ### 1.0.0.182
 
 - Fix Markdown rule violations in README.MD.


### PR DESCRIPTION
Get-JenkinsObject should use passed attributes when folder is specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/72)
<!-- Reviewable:end -->
