### PR TITLE
Added support for TLS 1.2 Jenkins Servers - Fixes #73

### DIFF
--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -98,7 +98,8 @@ function Set-JenkinsTLSSupport
     )
 
     if (-not ([Net.ServicePointManager]::SecurityProtocol).ToString().Contains([Net.SecurityProtocolType]::Tls12)) {
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol + [Net.SecurityProtocolType]::Tls12
+        [Net.ServicePointManager]::SecurityProtocol = `
+            [Net.ServicePointManager]::SecurityProtocol + [Net.SecurityProtocolType]::Tls12
     }
 } # function Set-JenkinsTLSSupport
 

--- a/Jenkins.psm1
+++ b/Jenkins.psm1
@@ -78,6 +78,30 @@ function New-Exception
     } # if
 } # function New-Exception
 
+<#
+.SYNOPSIS
+    Enables PowerShell to support TLS1.2 for communicating with
+    newer versions of Jenkins.
+.DESCRIPTION
+    This support cmdlet enables connecting to newer versions of
+    Jenkins over HTTPS. Newer versions of Jenkins have deprecated
+    support for SSL3/TLS, which are the default supported HTTPS
+    protocols.
+.OUTPUTS
+    None
+#>
+function Set-JenkinsTLSSupport
+{
+    [CmdLetBinding()]
+    param
+    (
+    )
+
+    if (-not ([Net.ServicePointManager]::SecurityProtocol).ToString().Contains([Net.SecurityProtocolType]::Tls12)) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol + [Net.SecurityProtocolType]::Tls12
+    }
+} # function Set-JenkinsTLSSupport
+
 
 <#
 .SYNOPSIS
@@ -195,6 +219,8 @@ function Get-JenkinsCrumb()
     try {
         Write-Verbose -Message $($LocalizedData.GetCrumbMessage -f
             $FullUri)
+
+        Set-JenkinsTLSSupport
 
         $Result = Invoke-WebRequest `
             -Uri $FullUri `
@@ -390,6 +416,8 @@ function Invoke-JenkinsCommand()
                 Write-Verbose -Message $($LocalizedData.InvokingRestApiCommandMessage -f
                     $FullUri)
 
+                Set-JenkinsTLSSupport
+
                 $Result = Invoke-RestMethod `
                     -Uri $FullUri `
                     -Headers $Headers `
@@ -410,6 +438,8 @@ function Invoke-JenkinsCommand()
             try {
                 Write-Verbose -Message $($LocalizedData.InvokingRestApiCommandMessage -f
                     $FullUri)
+
+                Set-JenkinsTLSSupport
 
                 $Result = Invoke-RestMethod `
                     -Uri $FullUri `
@@ -433,6 +463,8 @@ function Invoke-JenkinsCommand()
 
             Write-Verbose -Message $($LocalizedData.InvokingCommandMessage -f
                 $FullUri)
+
+            Set-JenkinsTLSSupport
 
             $Result = Invoke-WebRequest `
                 -Uri $FullUri `
@@ -462,6 +494,8 @@ function Invoke-JenkinsCommand()
             try {
                 Write-Verbose -Message $($LocalizedData.InvokingCommandMessage -f
                     $FullUri)
+
+                Set-JenkinsTLSSupport
 
                 $Result = Invoke-WebRequest `
                     -Uri $FullUri `
@@ -2096,6 +2130,8 @@ function Initialize-JenkinsUpdateCache()
     # Download the Remote Update Center JSON
     Write-Verbose -Message $($LocalizedData.DownloadingRemoteUpdateListMessage -f
         $Uri)
+
+    Set-JenkinsTLSSupport
 
     $remotePluginJSON = Invoke-WebRequest `
         -Uri $Uri `

--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,10 @@ For further examples, please see module help for individual cmdlets.
 
 ## Versions
 
+### Unreleased
+
+- Added support for Jenkins servers using TLS 1.2.
+
 ### 1.0.0.188
 
 - Fixed Get-JenkinsObject to use passed attributes when folder is specified.

--- a/tests/unit/Jenkins.tests.ps1
+++ b/tests/unit/Jenkins.tests.ps1
@@ -90,6 +90,12 @@ try
     $testJobName    = 'TestJob'
 
     InModuleScope 'Jenkins' {
+        Describe 'Set-JenkinsTLSSupport' {
+            It "should not throw" {
+                { Set-JenkinsTLSSupport } | Should Not Throw
+            }
+        }
+
         Describe 'Get-JenkinsTreeRequest' {
             Context 'default depth, default type, default attribute' {
                 It "should return '?tree=jobs[name,buildable,url,color]'" {
@@ -131,6 +137,8 @@ try
         }
 
         Context 'uri passed, credentials passed, standard crumb returned' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-WebRequest -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -147,6 +155,8 @@ try
                 $Result | Should Be '1234567890'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq ('{0}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)' -f $testURI) -and `
@@ -158,6 +168,8 @@ try
         } # Context
 
         Context 'uri passed, credentials passed, internal crumb returned' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-WebRequest -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -174,6 +186,8 @@ try
                 $Result | Should Be '1234567890'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq ('{0}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)' -f $testURI) -and `
@@ -185,6 +199,8 @@ try
         } # Context
 
         Context 'uri passed, credentials passed, invalid crumb returned' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-WebRequest -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -200,6 +216,8 @@ try
                 { $Result = Get-JenkinsCrumb @Splat } | Should Throw 'Invalid Crumb'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq ('{0}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)' -f $testURI) -and `
@@ -219,6 +237,8 @@ try
         }
 
         Context 'default type, default api, credentials passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-RestMethod -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -235,6 +255,8 @@ try
                 $Result | Should Be 'Invoke-RestMethod Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/api/json/$testCommand" -and `
@@ -246,6 +268,8 @@ try
         } # Context
 
         Context 'default type, default api, no credentials passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-RestMethod -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -263,6 +287,8 @@ try
                 $Result | Should Be 'Invoke-RestMethod Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName Jenkins `
                     -ParameterFilter {
                     $Uri -eq "$testURI/api/json/$testCommand" -and `
@@ -273,6 +299,8 @@ try
         } # Context
 
         Context 'default type, xml api, credentials passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-RestMethod -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -290,6 +318,8 @@ try
                 $Result | Should Be 'Invoke-RestMethod Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/api/xml/$testCommand" -and `
@@ -301,6 +331,8 @@ try
         } # Context
 
         Context 'default type, xml api, credentials passed, header passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-RestMethod -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -320,6 +352,8 @@ try
                 $Result | Should Be 'Invoke-RestMethod Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/api/xml/$testCommand" -and `
@@ -332,6 +366,8 @@ try
         } # Context
 
         Context 'default type, xml api, credentials passed, header passed, get method' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-RestMethod -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -353,6 +389,8 @@ try
                 $Result | Should Be 'Invoke-RestMethod Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/api/xml/$testCommand" -and `
@@ -366,6 +404,8 @@ try
         } # Context
 
         Context 'default type, xml api, credentials passed, body passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-RestMethod -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-RestMethod called with incorrect parameters' }
 
@@ -385,6 +425,8 @@ try
                 $Result | Should Be 'Invoke-RestMethod Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-RestMethod -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/api/xml/$testCommand" -and `
@@ -397,6 +439,8 @@ try
         } # Context
 
         Context 'command type, default api, credentials passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-WebRequest -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-WebRequest called with incorrect parameters' }
 
@@ -414,6 +458,8 @@ try
                 $Result | Should Be 'Invoke-WebRequest Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/$testCommand" -and `
@@ -425,6 +471,8 @@ try
         } # Context
 
         Context 'pluginmanager type, default api, credentials passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-WebRequest -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-WebRequest called with incorrect parameters' }
 
@@ -443,6 +491,8 @@ try
                 $Result | Should Be 'Invoke-WebRequest Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/pluginManager/api/json/?$testCommand" -and `
@@ -454,6 +504,8 @@ try
         } # Context
 
         Context 'pluginmanager type, xml api, credentials passed' {
+            Mock -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins
+
             Mock -CommandName Invoke-WebRequest -ModuleName Jenkins `
                 -MockWith { Throw 'Invoke-WebRequest called with incorrect parameters' }
 
@@ -473,6 +525,8 @@ try
                 $Result | Should Be 'Invoke-WebRequest Result'
             }
             It "should return call expected mocks" {
+                Assert-MockCalled -CommandName Set-JenkinsTLSSupport -ModuleName Jenkins -Exactly 1
+
                 Assert-MockCalled -CommandName Invoke-WebRequest -ModuleName Jenkins `
                     -ParameterFilter {
                         $Uri -eq "$testURI/pluginManager/api/xml/?$testCommand" -and `


### PR DESCRIPTION
This PR adds support for TLS 1.2 in newer versions of Jenkins Servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/74)
<!-- Reviewable:end -->
