### PR TITLE
Disable-JenkinsJob and Enable-JenkinsJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Added `Disable-JenkinsJob` and `Enable-JenkinsJob` functions for disabling
+  and enabling Jenkins jobs, respectively.
+
 ## 1.0.1.222
 
 - Jenkins 2.107.1 returns XML 1.1, which .NET can not parse. `Get-JenkinsJob`

--- a/readme.md
+++ b/readme.md
@@ -34,28 +34,27 @@ folder.
 
 ## Cmdlets
 
-- Get-JenkinsCrumb: Gets a Jenkins Crumb.
-- Invoke-JenkinsCommand: Execute a Jenkins command or request via the
-  Jenkins Rest API.
-- Get-JenkinsObject: Get a list of objects in a Jenkins master server.
-- Get-JenkinsJobList: Get a list of jobs in a Jenkins master server.
-- Get-JenkinsJob: Get a Jenkins Job Definition.
-- Set-JenkinsJob: Set a Jenkins Job definition.
-- Test-JenkinsJob: Determines if a Jenkins Job exists.
-- New-JenkinsJob: Create a new Jenkins Job.
-- Rename-JenkinsJob: Rename an existing Jenkins Job.
-- Remove-JenkinsJob: Remove an existing Jenkins Job.
-- Invoke-JenkinsJob: Run a parameterized or non-parameterized Jenkins
-  Job.
-- Get-JenkinsViewList: Get a list of views in a Jenkins master server.
-- Test-JenkinsView: Determines if a Jenkins View exists.
-- Get-JenkinsFolderList: Get a list of folders in a Jenkins master
-  server.
-- Test-JenkinsFolder: Determines if a Jenkins Folder exists.
-- Initialize-JenkinsUpdateCache: Creates or updates a local Jenkins
-  Update cache.
-- Get-JenkinsPluginsList: Retrieves a list of installed plugins.
-- Invoke-JenkinsJobReload: Reloads a job config on a given URL.
+- `Disable-JenkinsJob`: Disables a Jenkins job.
+- `Enable-JenkinsJob`: Enables a Jenkins job.
+- `Get-JenkinsCrumb`: Gets a Jenkins Crumb.
+- `Get-JenkinsFolderList`: Get a list of folders in a Jenkins master server.
+- `Get-JenkinsJob`: Get a Jenkins Job Definition.
+- `Get-JenkinsJobList`: Get a list of jobs in a Jenkins master server.
+- `Get-JenkinsObject`: Get a list of objects in a Jenkins master server.
+- `Get-JenkinsPluginsList`: Retrieves a list of installed plugins.
+- `Get-JenkinsViewList`: Get a list of views in a Jenkins master server.
+- `Initialize-JenkinsUpdateCache`: Creates or updates a local Jenkins Update cache.
+- `Invoke-JenkinsCommand`: Execute a Jenkins command or request via the Jenkins Rest API.
+- `Invoke-JenkinsJob`: Run a parameterized or non-parameterized Jenkins Job.
+- `Invoke-JenkinsJobReload`: Reloads a job config on a given URL.
+- `New-JenkinsJob`: Create a new Jenkins Job.
+- `Remove-JenkinsJob`: Remove an existing Jenkins Job.
+- `Rename-JenkinsJob`: Rename an existing Jenkins Job.
+- `Set-JenkinsJob`: Set a Jenkins Job definition.
+- `Test-JenkinsFolder`: Determines if a Jenkins Folder exists.
+- `Test-JenkinsJob`: Determines if a Jenkins Job exists.
+- `Test-JenkinsView`: Determines if a Jenkins View exists.
+
 
 ## Cross Site Request Forgery (CSRF) Support
 

--- a/src/Jenkins.psd1
+++ b/src/Jenkins.psd1
@@ -74,6 +74,7 @@
         'New-JenkinsJob'
         'Remove-JenkinsJob'
         'Rename-JenkinsJob'
+        'Resolve-JenkinsCommandUri',
         'Set-JenkinsJob'
         'Test-JenkinsFolder'
         'Test-JenkinsJob'

--- a/src/Jenkins.psd1
+++ b/src/Jenkins.psd1
@@ -59,6 +59,8 @@
 
     # Functions to export from this module
     FunctionsToExport = @(
+        'Disable-JenkinsJob'
+        'Enable-JenkinsJob'
         'Get-JenkinsCrumb'
         'Get-JenkinsFolderList'
         'Get-JenkinsJob'
@@ -74,7 +76,7 @@
         'New-JenkinsJob'
         'Remove-JenkinsJob'
         'Rename-JenkinsJob'
-        'Resolve-JenkinsCommandUri',
+        'Resolve-JenkinsCommandUri'
         'Set-JenkinsJob'
         'Test-JenkinsFolder'
         'Test-JenkinsJob'

--- a/src/en-US/Jenkins_LocalizationData.psd1
+++ b/src/en-US/Jenkins_LocalizationData.psd1
@@ -11,6 +11,8 @@ ConvertFrom-StringData -StringData @'
 
     NewJobMessage = Create the job '{0}'
     NewFolderMessage = Create the folder '{0}'
+    DisableJobMessage = Disable the job '{0}'
+    EnableJobMessage = Enable the job '{0}'
     RenameJobMessage = Rename the job '{0}' to '{1}'
     RemoveJobMessage = Delete the job '{0}'
     SetJobDefinitionMessage = Set the job definition for job '{0}'

--- a/src/lib/Disable-JenkinsJob.ps1
+++ b/src/lib/Disable-JenkinsJob.ps1
@@ -1,0 +1,68 @@
+function Disable-JenkinsJob
+{
+    [CmdLetBinding(SupportsShouldProcess = $true)]
+    [OutputType([System.String])]
+    param
+    (
+        [parameter(
+            Position = 1,
+            Mandatory = $true)]
+        [System.String]
+        $Uri,
+
+        [parameter(
+            Position = 2,
+            Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.CredentialAttribute()]
+        $Credential,
+
+        [parameter(
+            Position = 3,
+            Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Crumb,
+
+        [parameter(
+            Position = 4,
+            Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Folder,
+
+        [parameter(
+            Position = 5,
+            Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name
+    )
+
+    $null = $PSBoundParameters.Add('Type', 'Command')
+
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command 'disable'
+
+    $optionalParams = @{}
+    if( $Credential )
+    {
+        $optionalParams['Credential'] = $Credential
+    }
+
+    if( $Crumb )
+    {
+        $optionalParams['Crumb'] = $Crumb
+    }
+
+    $displayName = $Name
+    if( $Folder )
+    {
+        $displayName = '{0}/{1}' -f $Folder,$Name
+    }
+
+    if ($PSCmdlet.ShouldProcess( $Uri, $($LocalizedData.DisableJobMessage -f $displayName)))
+    {
+        $null = Invoke-JenkinsCommand -Uri $Uri -Type 'Command' -Command $Command -Method post @optionalParams
+    }
+}

--- a/src/lib/Enable-JenkinsJob.ps1
+++ b/src/lib/Enable-JenkinsJob.ps1
@@ -1,0 +1,69 @@
+
+function Enable-JenkinsJob
+{
+    [CmdLetBinding(SupportsShouldProcess = $true)]
+    [OutputType([System.String])]
+    param
+    (
+        [parameter(
+            Position = 1,
+            Mandatory = $true)]
+        [System.String]
+        $Uri,
+
+        [parameter(
+            Position = 2,
+            Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.CredentialAttribute()]
+        $Credential,
+
+        [parameter(
+            Position = 3,
+            Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Crumb,
+
+        [parameter(
+            Position = 4,
+            Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Folder,
+
+        [parameter(
+            Position = 5,
+            Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name
+    )
+
+    $null = $PSBoundParameters.Add('Type', 'Command')
+
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command 'enable'
+
+    $optionalParams = @{}
+    if( $Credential )
+    {
+        $optionalParams['Credential'] = $Credential
+    }
+
+    if( $Crumb )
+    {
+        $optionalParams['Crumb'] = $Crumb
+    }
+
+    $displayName = $Name
+    if( $Folder )
+    {
+        $displayName = '{0}/{1}' -f $Folder,$Name
+    }
+
+    if ($PSCmdlet.ShouldProcess( $Uri, $($LocalizedData.EnableJobMessage -f $displayName)))
+    {
+        $null = Invoke-JenkinsCommand -Uri $Uri -Type 'Command' -Command $Command -Method post @optionalParams
+    }
+}

--- a/src/lib/Get-JenkinsJob.ps1
+++ b/src/lib/Get-JenkinsJob.ps1
@@ -42,22 +42,7 @@ function Get-JenkinsJob
 
     $null = $PSBoundParameters.Add('Type', 'Command')
 
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
-        $Command = 'job/'
-
-        foreach ($Folder in $Folders)
-        {
-            $Command += "$Folder/job/"
-        } # foreach
-
-        $Command += "$Name/config.xml"
-    }
-    else
-    {
-        $Command = "job/$Name/config.xml"
-    } # if
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command 'config.xml'
 
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Folder')

--- a/src/lib/Invoke-JenkinsJob.ps1
+++ b/src/lib/Invoke-JenkinsJob.ps1
@@ -47,22 +47,7 @@ function Invoke-JenkinsJob
 
     $null = $PSBoundParameters.Add('Type', 'RestCommand')
 
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
-        $Command = 'job/'
-
-        foreach ($Folder in $Folders)
-        {
-            $Command += "$Folder/job/"
-        } # foreach
-
-        $Command += "$Name/build"
-    }
-    else
-    {
-        $Command = "job/$Name/build"
-    } # if
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command 'build'
 
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Folder')

--- a/src/lib/New-JenkinsFolder.ps1
+++ b/src/lib/New-JenkinsFolder.ps1
@@ -68,16 +68,9 @@ function New-JenkinsFolder
 "@
     }
     $null = $PSBoundParameters.Remove('XML')
-    $Command = ''
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
-        foreach ($Folder in $Folders)
-        {
-            $Command += "job/$Folder/"
-        } # foreach
-    } # if
-    $Command += "createItem?name=$Name"
+
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -Command "createItem?name=$Name"
+
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Description')
     $null = $PSBoundParameters.Remove('Folder')

--- a/src/lib/New-JenkinsJob.ps1
+++ b/src/lib/New-JenkinsJob.ps1
@@ -49,19 +49,9 @@ function New-JenkinsJob
     )
 
     $null = $PSBoundParameters.Add('Type', 'Command')
-    $Command = ''
 
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -Command ("createItem?name={0}" -f [System.Uri]::EscapeDataString($Name))
 
-        foreach ($Folder in $Folders)
-        {
-            $Command += "job/$Folder/"
-        } # foreach
-    } # if
-
-    $Command += "createItem?name={0}" -f [System.Uri]::EscapeDataString($Name)
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Folder')
     $null = $PSBoundParameters.Remove('XML')

--- a/src/lib/Remove-JenkinsJob.ps1
+++ b/src/lib/Remove-JenkinsJob.ps1
@@ -45,22 +45,7 @@ function Remove-JenkinsJob
 
     $null = $PSBoundParameters.Add('Type', 'Command')
 
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
-        $Command = 'job/'
-
-        foreach ($Folder in $Folders)
-        {
-            $Command += "$Folder/job/"
-        } # foreach
-
-        $Command += "$Name/doDelete"
-    }
-    else
-    {
-        $Command = "job/$Name/doDelete"
-    } # if
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command 'doDelete'
 
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Folder')

--- a/src/lib/Rename-JenkinsJob.ps1
+++ b/src/lib/Rename-JenkinsJob.ps1
@@ -52,22 +52,8 @@ function Rename-JenkinsJob
 
     $null = $PSBoundParameters.Add('Type', 'Command')
 
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
-        $Command = 'job/'
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command ("doRename?newName={0}" -f [System.Uri]::EscapeDataString($NewName))
 
-        foreach ($Folder in $Folders)
-        {
-            $Command += "$Folder/job/"
-        } # foreach
-    }
-    else
-    {
-        $Command = "job/"
-    } # if
-
-    $Command = "$Command$Name/doRename?newName={0}" -f [System.Uri]::EscapeDataString($NewName)
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('NewName')
     $null = $PSBoundParameters.Remove('Confirm')

--- a/src/lib/Resolve-JenkinsCommandUri.ps1
+++ b/src/lib/Resolve-JenkinsCommandUri.ps1
@@ -1,0 +1,46 @@
+
+function Resolve-JenkinsCommandUri
+{
+    [CmdLetBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [parameter(
+            Position = 1,
+            Mandatory = $false)]
+        [System.String]
+        $Folder,
+
+        [parameter(
+            Position = 2)]
+        [System.String]
+        $JobName,
+
+        [parameter(
+            Position = 3,
+            Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Command
+    )
+
+    $segments = & {
+                        if( $Folder )
+                        {
+                            ($Folder -split '\\') -split '/'
+                        }
+
+                        if( $JobName )
+                        {
+                            $JobName
+                        }
+                }
+    $uri = ''
+    if( $segments )
+    {
+        $uri = $segments -join '/job/'
+        $uri = ('job/{0}/' -f $uri)
+    }
+    return '{0}{1}' -f $uri,$Command
+}
+

--- a/src/lib/Set-JenkinsJob.ps1
+++ b/src/lib/Set-JenkinsJob.ps1
@@ -50,22 +50,7 @@ function Set-JenkinsJob
 
     $null = $PSBoundParameters.Add('Type', 'Command')
 
-    if ($PSBoundParameters.ContainsKey('Folder'))
-    {
-        $Folders = ($Folder -split '\\') -split '/'
-        $Command = 'job/'
-
-        foreach ($Folder in $Folders)
-        {
-            $Command += "$Folder/job/"
-        } # foreach
-
-        $Command += "$Name/config.xml"
-    }
-    else
-    {
-        $Command = "job/$Name/config.xml"
-    } # if
+    $Command = Resolve-JenkinsCommandUri -Folder $Folder -JobName $Name -Command 'config.xml'
 
     $null = $PSBoundParameters.Remove('Name')
     $null = $PSBoundParameters.Remove('Folder')

--- a/test/Resolve-JenkinsCommandUri.Tests.ps1
+++ b/test/Resolve-JenkinsCommandUri.Tests.ps1
@@ -1,0 +1,35 @@
+
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\src\Jenkins.psd1' -Resolve) -Force
+
+Describe 'Resolve-JenkinsCommandUri.when ony an endpoint' {
+    It ('should resolve' ) {
+        Resolve-JenkinsCommandUri -Command 'Fubar Snafu' | Should -Be 'Fubar Snafu'
+    }
+}
+
+Describe 'Resolve-JenkinsCommandUri.when folders seperated by forward slash' {
+    It ('should resolve' ) {
+        Resolve-JenkinsCommandUri -Command 'create' -Folder 'Fizz Buzz/Buzz Fizz' |
+            Should -Be 'job/Fizz Buzz/job/Buzz Fizz/create'
+    }
+}
+
+Describe 'Resolve-JenkinsCommandUri.when folders seperated by backward slash' {
+    It ('should resolve' ) {
+        Resolve-JenkinsCommandUri -Command 'create' -Folder 'Fizz Buzz\Buzz Fizz' |
+            Should -Be 'job/Fizz Buzz/job/Buzz Fizz/create'
+    }
+}
+
+Describe 'Resolve-JenkinsCommandUri.when passing a job name' {
+    It ('should resolve' ) {
+        Resolve-JenkinsCommandUri -Folder 'one/two/three' -JobName 'Fubar Snafu' -Command 'config.xml' | Should -Be 'job/one/job/two/job/three/job/Fubar Snafu/config.xml'
+    }
+}
+
+Describe 'Resolve-JenkinsCommandUri.when folder and job name are null' {
+    It ('should resolve' ) {
+        Resolve-JenkinsCommandUri -Folder $null -JobName $null -Command 'config.xml' | Should -Be 'config.xml'
+    }
+}
+

--- a/test/Resolve-JenkinsCommandUri.Tests.ps1
+++ b/test/Resolve-JenkinsCommandUri.Tests.ps1
@@ -2,33 +2,33 @@
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\src\Jenkins.psd1' -Resolve) -Force
 
 Describe 'Resolve-JenkinsCommandUri.when ony an endpoint' {
-    It ('should resolve' ) {
+    It 'should resolve' {
         Resolve-JenkinsCommandUri -Command 'Fubar Snafu' | Should -Be 'Fubar Snafu'
     }
 }
 
 Describe 'Resolve-JenkinsCommandUri.when folders seperated by forward slash' {
-    It ('should resolve' ) {
+    It 'should resolve' {
         Resolve-JenkinsCommandUri -Command 'create' -Folder 'Fizz Buzz/Buzz Fizz' |
             Should -Be 'job/Fizz Buzz/job/Buzz Fizz/create'
     }
 }
 
 Describe 'Resolve-JenkinsCommandUri.when folders seperated by backward slash' {
-    It ('should resolve' ) {
+    It 'should resolve' {
         Resolve-JenkinsCommandUri -Command 'create' -Folder 'Fizz Buzz\Buzz Fizz' |
             Should -Be 'job/Fizz Buzz/job/Buzz Fizz/create'
     }
 }
 
 Describe 'Resolve-JenkinsCommandUri.when passing a job name' {
-    It ('should resolve' ) {
+    It 'should resolve' {
         Resolve-JenkinsCommandUri -Folder 'one/two/three' -JobName 'Fubar Snafu' -Command 'config.xml' | Should -Be 'job/one/job/two/job/three/job/Fubar Snafu/config.xml'
     }
 }
 
 Describe 'Resolve-JenkinsCommandUri.when folder and job name are null' {
-    It ('should resolve' ) {
+    It 'should resolve' {
         Resolve-JenkinsCommandUri -Folder $null -JobName $null -Command 'config.xml' | Should -Be 'config.xml'
     }
 }


### PR DESCRIPTION
The main purpose of the PR is for new `Disable-JenkinsJob` and `Enable-JenkinsJob` functions. As part of this, I refactored the logic to resolve a command from a folder (optional), job name (optional), and command name into its own `Resolve-JenkinsCommandUri` function, which reduces a lot of code duplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/88)
<!-- Reviewable:end -->
