### PR TITLE
Correct documentation badge label - Fixes #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Corrected documentation badge label in READE.MD - fixes [issue #95](https://github.com/IAG-NZ/jenkins/issues/95).
+
 ## 1.0.2.240
 
 - Added `Disable-JenkinsJob` and `Enable-JenkinsJob` functions for disabling

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/IAG-NZ/Jenkins/blob/dev/LICENSE)
-[![Documentation - Jenkins](https://img.shields.io/badge/Documentation-CosmosDB-blue.svg)](https://github.com/IAG-NZ/Jenkins/wiki)
+[![Documentation - Jenkins](https://img.shields.io/badge/Documentation-Jenkins-blue.svg)](https://github.com/IAG-NZ/Jenkins/wiki)
 [![PowerShell Gallery - Jenkins](https://img.shields.io/badge/PowerShell%20Gallery-Jenkins-blue.svg)](https://www.powershellgallery.com/packages/Jenkins)
 [![Minimum Supported PowerShell Version](https://img.shields.io/badge/PowerShell-4.0-blue.svg)](https://github.com/IAG-NZ/Jenkins)
 [![Minimum Supported PowerShell Core Version](https://img.shields.io/badge/PowerShell_Core-6.0-blue.svg)](https://github.com/IAG-NZ/Jenkins)


### PR DESCRIPTION
The documentation label in the README.MD referred to CosmosDB instead of Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iag-nz/jenkins/96)
<!-- Reviewable:end -->
